### PR TITLE
update firewall script to postpone whitelist apply

### DIFF
--- a/openwrt/usr/bin/shadowsocks-firewall
+++ b/openwrt/usr/bin/shadowsocks-firewall
@@ -2,6 +2,7 @@
 
 #create a new chain named SHADOWSOCKS
 iptables -t nat -N SHADOWSOCKS
+iptables -t nat -N SHADOWSOCKS_WHITELIST
 
 # Ignore your shadowsocks server's addresses
 # It's very IMPORTANT, just be careful.
@@ -18,55 +19,60 @@ iptables -t nat -A SHADOWSOCKS -d 192.168.0.0/16 -j RETURN
 iptables -t nat -A SHADOWSOCKS -d 224.0.0.0/4 -j RETURN
 iptables -t nat -A SHADOWSOCKS -d 240.0.0.0/4 -j RETURN
 
-# Ignore Asia IP address
-iptables -t nat -A SHADOWSOCKS -d 1.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 14.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 27.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 36.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 39.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 42.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 49.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 58.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 59.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 60.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 61.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 101.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 103.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 106.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 110.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 111.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 112.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 113.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 114.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 115.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 116.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 117.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 118.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 119.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 120.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 121.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 122.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 123.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 124.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 125.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 126.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 169.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 175.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 180.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 182.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 183.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 202.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 203.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 210.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 211.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 218.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 219.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 220.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 221.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 222.0.0.0/8 -j RETURN
-iptables -t nat -A SHADOWSOCKS -d 223.0.0.0/8 -j RETURN
+# Check whitelist
+iptables -t nat -A SHADOWSOCKS -j SHADOWSOCKS_WHITELIST
+iptables -t nat -A SHADOWSOCKS -m mark --mark 1 -j RETURN
 
 # Anything else should be redirected to shadowsocks's local port
 iptables -t nat -A SHADOWSOCKS -p tcp -j REDIRECT --to-ports 8024
 # Apply the rules
 iptables -t nat -A PREROUTING -p tcp -j SHADOWSOCKS
+
+# Ignore Asia IP address
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 1.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 14.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 27.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 36.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 39.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 42.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 49.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 58.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 59.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 60.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 61.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 101.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 103.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 106.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 110.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 111.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 112.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 113.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 114.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 115.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 116.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 117.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 118.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 119.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 120.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 121.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 122.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 123.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 124.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 125.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 126.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 169.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 175.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 180.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 182.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 183.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 202.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 203.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 210.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 211.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 218.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 219.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 220.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 221.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 222.0.0.0/8 -j MARK --set-mark 1
+iptables -t nat -A SHADOWSOCKS_WHITELIST -d 223.0.0.0/8 -j MARK --set-mark 1
+


### PR DESCRIPTION
Make sure whitelist applies later than the port-forwarding to shadowsocks. This provides uncensored Internet access faster from a cold-boot, by first running in a all-proxy mode and slowing working on the whitelist. Useful if whitelist is extremely long (>2000 lines to exact match China IPs).