### PR TITLE
Exclude url with path for adblock list generating.

### DIFF
--- a/ebook/03.6.md
+++ b/ebook/03.6.md
@@ -25,11 +25,11 @@ dnsmasq支持基于域名的广告屏蔽方式，这种屏蔽方式比较粗糙�
 
 	adblock() {                                                                                                                                                             
 	    wget -4 --no-check-certificate -O - https://easylist-downloads.adblockplus.org/easylistchina+easylist.txt |                                                     
-	    grep ^\|\|[^\*]*\^$ |                                                                                                                                           
+	    grep ^\|\|[^\*/]*\^$ |                                                                                                                                           
 	    sed -e 's:||:address\=\/:' -e 's:\^:/127\.0\.0\.1:' | uniq > /etc/dnsmasq.d/adblock.conf                                                                        
 	                                                                                                                                                                        
 	    wget -4 --no-check-certificate -O - https://raw.githubusercontent.com/kcschan/AdditionalAdblock/master/list.txt |                                               
-	    grep ^\|\|[^\*]*\^$ |                                                                                                                                           
+	    grep ^\|\|[^\*/]*\^$ |                                                                                                                                           
 	    sed -e 's:||:address\=\/:' -e 's:\^:/127\.0\.0\.1:' >> /etc/dnsmasq.d/adblock.conf                                                                              
 	} 
 
@@ -42,11 +42,11 @@ dnsmasq支持基于域名的广告屏蔽方式，这种屏蔽方式比较粗糙�
 	} 		
 	adblock() {                                                                                                                                                             
 	    wget -4 --no-check-certificate -O - https://easylist-downloads.adblockplus.org/easylistchina+easylist.txt |                                                     
-	    grep ^\|\|[^\*]*\^$ |                                                                                                                                           
+	    grep ^\|\|[^\*/]*\^$ |                                                                                                                                           
 	    sed -e 's:||:address\=\/:' -e 's:\^:/127\.0\.0\.1:' | uniq > /etc/dnsmasq.d/adblock.conf                                                                        
 	                                                                                                                                                                        
 	    wget -4 --no-check-certificate -O - https://raw.githubusercontent.com/kcschan/AdditionalAdblock/master/list.txt |                                               
-	    grep ^\|\|[^\*]*\^$ |                                                                                                                                           
+	    grep ^\|\|[^\*/]*\^$ |                                                                                                                                           
 	    sed -e 's:||:address\=\/:' -e 's:\^:/127\.0\.0\.1:' >> /etc/dnsmasq.d/adblock.conf                                                                              
 	} 
 	cnlist


### PR DESCRIPTION
Update regex in order to exclude url with path (like `||m.baidu.com/xcloudboss^`).

The example url mentioned above will generate `address=/m.baidu.com/xcloudboss/127.0.0.1` in the adblock list with previous regex. And it will block all requests to `m.baidu.com`. I think it's totally wrong, so I create this pull request.