### PR TITLE
Update 04.1.md

### DIFF
--- a/ebook/04.1.md
+++ b/ebook/04.1.md
@@ -30,10 +30,13 @@
 	
 	编译 DIR505固件2015-12版时用的源码版本是：Date:   Tue Dec 22 21:42:40 2015
 
-## 更新Feeds，使package在make menuconfig中可用，而不是真正安装或编译
+## 更新Feeds，使package在make menuconfig中可用，而不是真正安装或编译，并按照自己的路由型号设定target，否则默认target下编译好的工具链在重新设定target后无效
 	cd ~/Downloads/openwrt
 	./scripts/feeds update -a
 	./scripts/feeds install -a	
+	# run make menuconfig and set target; 
+	# Choose your own Target System -> SubTarget -> Target Profile
+	make menuconfig
 	make defconfig
 	
 ## 先编译要用到的工具和库


### PR DESCRIPTION
在运行`make defconfig` 之前应该先设定 `target`，否则默认的`target`下编译出的工具链在重新设定`target`后，不能继续使用，需要重新编译。